### PR TITLE
only require np.allclose instead of exact equality for _check_all_same

### DIFF
--- a/nnunetv2/imageio/base_reader_writer.py
+++ b/nnunetv2/imageio/base_reader_writer.py
@@ -23,7 +23,7 @@ class BaseReaderWriter(ABC):
     def _check_all_same(input_list):
         # compare all entries to the first
         for i in input_list[1:]:
-            if i != input_list[0]:
+            if not np.allclose(i, input_list[0]):
                 return False
         return True
 


### PR DESCRIPTION
Running verify_dataset_integrity() checks all input images to make sure they have the exact same spacing, shape, direction, and origin. As a result, if there are negligible (e.g., 1e-10) discrepancies among images, it raises an error when none should be raised.

Here, we replace the check in BaseReaderWriter._check_all_same()  for exact equality with a check for closeness, just as in the similar method BaseReaderWriter._check_all_same_array()